### PR TITLE
Lock to <2.2.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,10 @@
     "name": "rubic/magento2-module-clean-checkout-newsletter",
     "type": "magento2-module",
     "license": "MIT",
+    "require": {
+        "magento/framework": "<=101.0.11",
+        "magento/module-checkout": "<=100.2.11"
+    },
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
2.3 and 2.4 releases may not be backwards compatible, and will use a ^2.1 version number.